### PR TITLE
Remove "git commit -a"

### DIFF
--- a/2-working.md
+++ b/2-working.md
@@ -202,7 +202,7 @@ prompt you to use `git commit -a` or `git commit --all`, which is kind
 of like saying, "ok, *everyone in this one!*". However, it's almost
 always better to explicitly add things to the staging area, because
 you might otherwise commit changes you forgot you made. Going back to
-the project snaphsots, you might get the extra with the incomplete
+the snapshots analogy, you might get the extra with the incomplete
 makeup walking in and ruining the picture because you used `-a`! Try
 to stage things manually, or you might find yourself searching for
 "git undo commit" more than you would like!

--- a/2-working.md
+++ b/2-working.md
@@ -372,7 +372,8 @@ but the Mummy will appreciate the lack of humidity.
 Commit that change:
 
 {% highlight console %}
-$ git commit -a -m "Add title and heading"
+$ git add mars.txt
+$ git commit -m "Add title and heading"
 {% endhighlight %}
 
 ... and add a heading for human-focused concerns:
@@ -392,7 +393,8 @@ but the Mummy will appreciate the lack of humidity.
 Now commit, return to the master branch, and make some unrelated changes:
 
 {% highlight console %}
-$ git commit -a -m "Add heading for human-specific concerns"
+$ git add mars.txt
+$ git commit -m "Add heading for human-specific concerns"
 $ git checkout master
 {% endhighlight %}
 
@@ -407,7 +409,8 @@ but the Mummy will appreciate the lack of humidity.
 And commit those changes:
 
 {% highlight console %}
-$ git commit -a -m "Improve English style by replacing 2 with two"
+$ git add mars.txt
+$ git commit -m "Improve English style by replacing 2 with two"
 {% endhighlight %}
 
 Now, you've thought about the "headings" branch and decide it's time to
@@ -466,7 +469,8 @@ but the Mummy will appreciate the lack of humidity.
 Commit the change:
 
 {% highlight console %}
-$ git commit -a -m "Change Dracula reference to the third person"
+$ git add mars.txt
+$ git commit -m "Change Dracula reference to the third person"
 {% endhighlight %}
 
 Now, a pedantic member of the team (let's call them "Juan Nunez-Iglesias")
@@ -495,7 +499,8 @@ but the Mummy will appreciate the lack of humidity.
 And commit our changes:
 
 {% highlight console %}
-$ git commit -a -m "Complete first sentence"
+$ git add mars.txt
+$ git commit -m "Complete first sentence"
 {% endhighlight %}
 
 Finally, we get back the master branch and try to merge each branch in

--- a/3-github.md
+++ b/3-github.md
@@ -109,7 +109,8 @@ the `--set-upstream` function, you tell git to create a branch with the same
 name that "tracks" the current branch. This makes future pushes easier.
 
 {% highlight console %}
-$ git commit -a -m "Add human concerns about oxygen"
+$ git add mars.txt
+$ git commit -m "Add human concerns about oxygen"
 $ git push origin --set-upstream humans
 {% endhighlight %}
 
@@ -145,8 +146,8 @@ title and message here is very important!
 > 
 > When in Rome, do as the Romans do. Look at their existing codebase
 > and try to follow their example. (This is not to say that you can't
-> improve on it; but make sure your documentation and testing *at
-> least* meets their standards.)
+> improve on it; but make sure your documentation and testing *at least*
+> least meets their standards.)
 
 
 
@@ -180,7 +181,8 @@ We can extract it from CO2, which is plentiful on Mars.
 Again, Bob commits and pushes his changes:
 
 {% highlight console %}
-$ git commit -a -m "Specify how to obtain oxygen on Mars"
+$ git add mars.txt
+$ git commit -m "Specify how to obtain oxygen on Mars"
 $ git push  # no need to specify repo or branch anymore, having `set-upstream`
 {% endhighlight %}
 


### PR DESCRIPTION
@hdashnow I thought this was particularly ironic:

```
nuneziglesiasj@jni-lscc-mbp Mon Nov 02 17:31
 ~/projects/git-tutorial (fixes)$ git ci -a -m "Replace all uses of commit -a"
```
=P =P =P